### PR TITLE
Remove old webpack-universal comment from import.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
 require('colors')
 const express = require('express')
-const webpack = require('webpack') // aliased to webpack-universal
+const webpack = require('webpack')
 const noFavicon = require('express-no-favicons')
 const webpackDevMiddleware = require('webpack-dev-middleware')
 const webpackHotMiddleware = require('webpack-hot-middleware')


### PR DESCRIPTION
Remove an old comment which caused me to track down webpack-universal and try to figure out what the differences were between webpack and the fork. (Nothing now!)