### PR TITLE
demo universalImport not thennable when used in conjunction with universal-component

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -12,6 +12,11 @@ const UniversalComponent = universal(props => import(`./${props.page}`), {
   error: NotFound
 })
 
+const UniversalParagraph = universal(
+  import('./group.js').then(({ Paragraph }) => Paragraph)
+)
+const UniversalBold = universal(import('./group.js').then(({ Bold }) => Bold))
+
 export default class App extends React.Component {
   render() {
     const { index, done, loading } = this.state
@@ -36,6 +41,11 @@ export default class App extends React.Component {
         <button className={buttonClass} onClick={this.changePage}>
           {this.buttonText()}
         </button>
+
+        <UniversalParagraph>
+          <UniversalBold>This is Bold Text</UniversalBold>
+          and some not bold text
+        </UniversalParagraph>
 
         <p>
           <span>*why are you looking at this? refresh the page</span>

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+const Paragraph = props => <p {...props} />
+const Bold = props => <strong {...props} />
+
+export { Paragraph, Bold }
+
+// no default export


### PR DESCRIPTION
to demo behavior described in https://github.com/faceyspacey/babel-plugin-universal-import/issues/37

the output of the usage of `<UniversalParagraph>....</UniversalParagraph>' (as well as the `<UniversalBold>` Component) in this case is `Error: load is not a function`