### PR TITLE
fix(index.js): Remove undefined AppContainer component which was the …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,15 +5,11 @@ import App from './components/App'
 
 const history = createHistory()
 
-const render = App => ReactDOM.hydrate(
-  <AppContainer>
-    <App history={history} />
-  </AppContainer>,
-  document.getElementById('root')
-)
+const render = App => ReactDOM.hydrate(<App history={history} />, document.getElementById('root'))
 
 if (process.env.NODE_ENV === 'development' && module.hot) {
   module.hot.accept('./components/App.js', () => {
+    // eslint-disable-next-line global-require
     const App = require('./components/App').default // eslint-ignore-line
     render(App)
   })


### PR DESCRIPTION
…cause of error

Removed undefined AppContainer in src/index.js due to this component app is not working fine means
it is impacting the app functionality. Alos added es-lint comment to resolve the es-lint warning.