### PR TITLE
fix: client prod file should not set dev mode

### DIFF
--- a/webpack/client.prod.js
+++ b/webpack/client.prod.js
@@ -39,7 +39,7 @@ module.exports = {
       }
     ]
   },
-  mode: 'development',
+  mode: 'production',
   resolve: {
     extensions: ['.js', '.css', '.styl']
   },


### PR DESCRIPTION
webpack 'mode: production' config is explicitly setting the default 'production'  setting.